### PR TITLE
[ADD] ability to move a package into another package when stock.picki…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # package_hierarchy
+
+Extend stock.quant.package model to work with parent packages, which in some cases is needed when working with packages inside pallets.
+
+## Features of this module
+
+This module adds the following features:
+* Ability to set the parent package of a package
+* Ability to move a package into another package when a stock.picking is done
+* Check that all the content of a parent package is in the same location
+
+
+## To change
+* Change fields x_field_name to u_field_name
+* Stock.quant.packge has a field name called parent_ids but in the compute function uses ancestor_ids
+* Parent package is only shonw at package view if it is set, change it to be able to set it when it is emptye
+* Packages button (top right of stock.picking.form view) only shows packages, update it to also show parent packages
+* x_selected still needed? Probably we can remove it and add it later if we need to palletise using UI

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -13,6 +13,7 @@
     ],
     'data': [
         'views/stock_quant_views.xml',
+        'views/stock_move_views.xml',
         'views/stock_picking_views.xml',
     ],
     'qweb': [

--- a/models/stock_move_line.py
+++ b/models/stock_move_line.py
@@ -1,7 +1,55 @@
-from odoo import models, fields
+# -*- coding: utf-8 -*-
+
+from odoo import api, models, fields, _
+from odoo.exceptions import ValidationError
 
 
 class StockMoveLine(models.Model):
     _inherit = 'stock.move.line'
 
     x_selected = fields.Boolean(string=' ', help='Check this box to select')
+
+    u_result_parent_package_id = fields.Many2one('stock.quant.package',
+                    'Parent Destination Package', ondelete='restrict')
+
+    def _action_done(self):
+        """ When a move_line is done and it has result_package_id its
+            parent will be removed if u_result_parent_package_id is empty,
+            otherwise it will be updated to be u_result_parent_package_id.
+        """
+        super(StockMoveLine, self)._action_done()
+
+        for ml in self:
+            result_parent = ml.u_result_parent_package_id
+            result_package = ml.result_package_id
+            if result_parent:
+                if result_package:
+                    # only update if it is different
+                    if result_package.package_id != result_parent:
+                        result_package.package_id = result_parent
+                else:
+                    raise ValidatinError(
+                            _('Result parent package without result'
+                              ' package at picking %s') % ml.picking_id.name)
+            else:
+                if result_package and result_package.package_id:
+                    result_package.package_id = False
+
+    @api.constrains('u_result_parent_package_id')
+    @api.onchange('u_result_parent_package_id')
+    def _assert_one_parent_package(self):
+        """ Checks that there is only one parent package per result_package_id
+        """
+        for ml in self:
+            result_parent = ml.u_result_parent_package_id
+            if result_parent:
+                result_package = ml.result_package_id
+                # get lines with the same result_package_id that have u_result_parent_package_id
+                lines = ml.picking_id.mapped('move_line_ids').filtered(lambda l: l.result_package_id == result_package and
+                                                                                 l.u_result_parent_package_id)
+                parents = lines.mapped('u_result_parent_package_id')
+                if len(parents) > 1:
+                    raise ValidationError(
+                            _('Multiple result parent packages for package %s found %s.') %
+                                (result_package.name, ' '.join(parents.mapped('name')))
+                            )

--- a/models/stock_move_line.py
+++ b/models/stock_move_line.py
@@ -28,7 +28,7 @@ class StockMoveLine(models.Model):
                     if result_package.package_id != result_parent:
                         result_package.package_id = result_parent
                 else:
-                    raise ValidatinError(
+                    raise ValidationError(
                             _('Result parent package without result'
                               ' package at picking %s') % ml.picking_id.name)
             else:

--- a/models/stock_quant_package.py
+++ b/models/stock_quant_package.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError

--- a/views/stock_move_views.xml
+++ b/views/stock_move_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+        <record id="view_stock_move_line_operation_tree" model="ir.ui.view">
+            <field name="name">stock.move.line.operations.tree</field>
+            <field name="inherit_id" ref="stock.view_stock_move_line_operation_tree"/>
+            <field name="model">stock.move.line</field>
+            <field name="arch" type="xml">
+
+                <xpath expr="//field[@name='result_package_id']" position="after">
+                    <field name="u_result_parent_package_id" attrs="{'readonly': [('result_package_id', '=', False)]}"
+                        groups="stock.group_tracking_lot" />
+                </xpath>
+
+            </field>
+        </record>
+
+</odoo>

--- a/views/stock_picking_views.xml
+++ b/views/stock_picking_views.xml
@@ -13,6 +13,11 @@
                 <field name="x_pallet_id" />
                 <button name="palletise" type="object" string="Palletise"/>
             </xpath>
+
+            <xpath expr="//field[@name='result_package_id']" position="after">
+                <field name="u_result_parent_package_id" attrs="{'readonly': [('result_package_id', '=', False)]}"
+                    groups="stock.group_tracking_lot" />
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
…ng is done

- Add field u_result_parent_package_id to stock.move.line
- Update stock.picking and stock.move views to show u_result_parent_package_id
- Extend stock.move.line._action_done() to handle u_result_parent_packge_id
- Extend stock.picking._check_entire_pack() to set u_result_parent_package_id
- Constrain that there is only one result parent package per result_package_id
in a stock.picking.